### PR TITLE
Rossica

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -371,7 +371,7 @@ done
 handle_message 'Old backups deleted, deleting any remaining incomplete folders.'
 
 # Remove any remaining incomplete folders at target, those belong to ghost processes.
-${ssh_executable} -p ${ssh_port} ${ssh_connect} "find '${target}' -type d -maxdepth 1 -name '*incomplete' -exec rm -rf {} \;"
+${ssh_executable} -p ${ssh_port} ${ssh_connect} "find '${target}' -type d -maxdepth 1 -name '*incomplete' -exec rm -rf {} +"
 
 if [ $? = 0 ]
 then

--- a/backup.sh
+++ b/backup.sh
@@ -9,6 +9,10 @@ script_dir=$(/usr/bin/dirname "${script}")
 # Date for this backup.
 date=`date '+%Y-%m-%d_%Hh%Mm%Ss'`
 
+# Set default intervals for deleting multiple log files, in days.
+delete_logfile_interval=7
+delete_error_logfile_interval=30
+
 # include settings
 . "${script_dir}/settings.inc"
 
@@ -394,10 +398,10 @@ handle_message "-- Backup to '${target}hourly/${date}' finished" 'Backup script 
 if [ "${single_logfile}" == 'false' ]
 then
   # Delete successful log files older than a week.
-  find ${logdir} -maxdepth 1 -type f -mtime +7 | xargs rm -f
+  find ${logdir} -maxdepth 1 -type f -mtime +${delete_logfile_interval} | xargs rm -f
   
   # Delete error log files older than a month.
-  find ${logdir}/error -maxdepth 1 -type f -mtime +30 | xargs rm -f
+  find ${logdir}/error -maxdepth 1 -type f -mtime +${delete_error_logfile_interval} | xargs rm -f
 fi
 
 exit 0; # successful termination

--- a/backup.sh
+++ b/backup.sh
@@ -46,6 +46,12 @@ executable='/usr/bin/notify-send'
   fi
 }
 
+# Create log directory if it doesn't exist
+if [ ! -d '${script_dir}/log' ]
+then
+  mkdir ${script_dir}/log
+fi
+
 # Make sure the system wide version of each executable used.
 ssh_executable='/usr/bin/ssh'
 rsync_executable='/usr/bin/rsync'

--- a/backup.sh
+++ b/backup.sh
@@ -282,7 +282,7 @@ handle_message 'Backups rotated, deleting old backups.'
 # To determine when to delete a backup from ie hourly it must be older then
 # the given amount of days. Note, because of this deletion, the rotation is
 # done before it.
-delete0='0' # Hourly backups older then 1 day are removed.
+delete0='1' # Hourly backups older then 1 day are removed.
 delete1='7' # Daily backups older then 7 days are removed.
 delete2='30' # Weekly backups older then 30 days (approx. 1 month) are removed.
 delete3='365' # Monthly backups older then 365 days (approx. 1 year) are removed.

--- a/settings.inc.example
+++ b/settings.inc.example
@@ -5,6 +5,7 @@ backup='"/media/Data/Pictures"
 "/media/Data/Documents"
 "/home/johndoe/.settings"'
 target='/mnt/dev1/backup/'
+single_logfile='true'
 ssh_user='JohnDoe'
 ssh_server='BackupStorage'
 ssh_port='22'


### PR DESCRIPTION
1. Added support for unique log files for each backup. The goal is to prevent having one giant log file after a few months of back ups.  To correlate any errors experienced with the backup folder that had the error, the log file date and folder date are the same.
2. The script will now link against any previous incomplete backup. If a back up client has a lot of data to back up and a slow upload speed coupled with unreliable internet connectivity, this will enable the client to complete their back up eventually.
   Previously, the client would start from scratch every attempt, which means the client needs no (connectivity) issues for the (sometimes long) duration of the backup, in order to successfully back up any data; it's all or nothing.  Now, if there is an error, or if the connectivity between client and server is disrupted, the next attempt will start with any unchanged files already uploaded.
3. Added support in the -v switch to have rsync also log to the timebackup log file. This may be handy for cron scripts.
4. Added the --stats switch with to rsync when being verbose because I'm a numbers geek :smile: 
5. Fixed a small typo in the error text.
6. When backing up to FreeNAS, the observed behavior of finding files that are 0 days old in the hourly folder would lead to all backups being deleted from the hourly folder. This had the effect of deleting all backups, and thus none would get rotated from the hourly folder. 

All changes tested with clients:
windows (7, 8.1) with cygwin,
ArchLinux.
Targeting a FreeNAS server.

Your thoughts, @Mondane ?
